### PR TITLE
PIE-1362: Add collector name and version to Analytics API payload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "buildkite-test-collector"
 readme = "README.md"
 repository = "https://github.com/buildkite/test-collector-rust"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}

--- a/src/run_env.rs
+++ b/src/run_env.rs
@@ -5,6 +5,9 @@
 use std::env;
 use uuid::Uuid;
 
+static VERSION: &str = env!("CARGO_PKG_VERSION");
+static COLLECTOR_NAME: &str = env!("CARGO_PKG_NAME");
+
 /// # RuntimeEnvironment
 ///
 /// A data structure containing information about the detected CI environment.
@@ -18,6 +21,8 @@ pub struct RuntimeEnvironment {
     commit_sha: Option<String>,
     message: Option<String>,
     url: Option<String>,
+    collector: String,
+    version: String,
 }
 
 impl RuntimeEnvironment {
@@ -43,6 +48,8 @@ impl RuntimeEnvironment {
             commit_sha: None,
             message: None,
             url: None,
+            collector: format!("rust-{}", COLLECTOR_NAME.to_string()),
+            version: VERSION.to_string(),
         }
     }
 }
@@ -59,6 +66,8 @@ fn buildkite_env() -> Option<RuntimeEnvironment> {
         number: maybe_var("BUILDKITE_BUILD_NUMBER"),
         job_id: maybe_var("BUILDKITE_JOB_ID"),
         message: maybe_var("BUILDKITE_MESSAGE"),
+        collector: format!("rust-{}", COLLECTOR_NAME.to_string()),
+        version: VERSION.to_string(),
     })
 }
 
@@ -78,6 +87,8 @@ fn github_actions_env() -> Option<RuntimeEnvironment> {
         number: Some(run_number),
         job_id: None,
         message: None,
+        collector: format!("rust-{}", COLLECTOR_NAME.to_string()),
+        version: VERSION.to_string(),
     })
 }
 
@@ -94,6 +105,8 @@ fn circle_ci_env() -> Option<RuntimeEnvironment> {
         number: Some(build_num),
         job_id: None,
         message: None,
+        collector: format!("rust-{}", COLLECTOR_NAME.to_string()),
+        version: VERSION.to_string(),
     })
 }
 
@@ -109,6 +122,8 @@ fn generic_env() -> Option<RuntimeEnvironment> {
         commit_sha: None,
         message: None,
         url: None,
+        collector: format!("rust-{}", COLLECTOR_NAME.to_string()),
+        version: VERSION.to_string(),
     })
 }
 
@@ -154,6 +169,8 @@ mod test {
             assert_eq!(env.number, Some(number));
             assert_eq!(env.job_id, Some(job_id));
             assert_eq!(env.message, Some(message));
+            assert_eq!(env.version, VERSION);
+            assert_eq!(env.collector, format!("rust-{}", COLLECTOR_NAME.to_string()));
         });
     }
 
@@ -198,6 +215,8 @@ mod test {
             assert_eq!(env.number, Some(run_number));
             assert_eq!(env.job_id, None);
             assert_eq!(env.message, None);
+            assert_eq!(env.version, VERSION);
+            assert_eq!(env.collector, format!("rust-{}", COLLECTOR_NAME.to_string()));
         })
     }
 
@@ -229,6 +248,8 @@ mod test {
             assert_eq!(env.number, Some(build_num));
             assert_eq!(env.job_id, None);
             assert_eq!(env.message, None);
+            assert_eq!(env.version, VERSION);
+            assert_eq!(env.collector, format!("rust-{}", COLLECTOR_NAME.to_string()));
         });
     }
 
@@ -249,6 +270,8 @@ mod test {
             assert_eq!(env.commit_sha, None);
             assert_eq!(env.message, None);
             assert_eq!(env.url, None);
+            assert_eq!(env.version, VERSION);
+            assert_eq!(env.collector, format!("rust-{}", COLLECTOR_NAME.to_string()));
         });
     }
 


### PR DESCRIPTION
### Context
TA is working on displaying a tally of the types of collectors our customers are using. We can gather this data via the collector names and versions, however some collectors are missing this data (please see [related linear ticket](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc) for list).

This collector will now emit the collector name "**rust-buildkite-test-collector**"

---

Linear tickets
[Linear Ticket](https://linear.app/buildkite/issue/PIE-1362/add-collector-name-and-version-to-rust-test-collector)
[Related Linear Ticket](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc)