### PR TITLE
PIE-1481 Remove identifier from Rust test collector payloads

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -32,7 +32,6 @@ pub struct TestData {
     id: String,
     scope: String,
     name: String,
-    identifier: String,
     #[serde(flatten)]
     result: TestResult,
     history: TestHistory,
@@ -189,7 +188,6 @@ impl Payload {
                 let data = TestData {
                     id: Uuid::new_v4().to_string(),
                     name: name_chunks.iter().last().unwrap().to_string(),
-                    identifier: name.clone(),
                     scope: name_chunks
                         .iter()
                         .rev()
@@ -305,7 +303,6 @@ mod test {
             id: uuid.clone(),
             scope: uuid.clone(),
             name: uuid.clone(),
-            identifier: uuid,
             result: stub_test_result(),
             history: stub_test_history(finished),
         }


### PR DESCRIPTION
Description
We have removed identifier field from DB test table, and we no longer using it in TA.
This PR is for removing identifier from this collector so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561)

Context
Ticket: https://linear.app/buildkite/issue/PIE-1481/remove-identifier-from-rust-test-collector-payloads
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

Change
Remove identifier from the collector
Fix failing tests caused by the changes