### PR TITLE
Bump Rust Test Collector patch version from 0.1.1 to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "buildkite-test-collector"
 readme = "README.md"
 repository = "https://github.com/buildkite/test-collector-rust"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}


### PR DESCRIPTION
https://github.com/buildkite/test-collector-rust/compare/0.1.1...0.1.2