### PR TITLE
Bump rustls-webpki to 0.103.13 to fix GHSA-82j2-j2ch-gfr8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -665,15 +665,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Description

Dependabot raised [GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8): `rustls-webpki` denial of service via panic on malformed CRL BIT STRING. The vulnerable version (0.102.8) was locked transitively via `ureq 3.3.0 -> rustls 0.23.22 -> rustls-webpki 0.102.8`.

Dependabot's auto-fix failed:

> Dependabot cannot update rustls-webpki to a non-vulnerable version. The latest possible version of rustls-webpki that can be installed is 0.102.8. The earliest fixed version is 0.103.13.

The 0.102 → 0.103 major bump of `rustls-webpki` requires a minor bump of `rustls`, which Dependabot couldn't resolve in isolation when both are transitive dependencies.

## Changes

Lockfile-only update (no `Cargo.toml` change required):

- `rustls`: 0.23.22 → 0.23.28
- `rustls-webpki`: 0.102.8 → **0.103.13** (the fixed version)
- `rustls-pki-types`: 1.11.0 → 1.14.1

Reproduce locally with:

```sh
cargo update rustls
cargo update rustls-webpki --precise 0.103.13
```

## Verification

- `cargo build` succeeds
- `cargo test` passes (6/6 tests)

## Rollback

Revert the commit. Lockfile-only change with no API surface impact; safe to revert.

### Related

- Resolves TE-5740
- https://github.com/advisories/GHSA-82j2-j2ch-gfr8